### PR TITLE
Fix: Adding check for when touching unpersisted object

### DIFF
--- a/lib/active_record/events/method_factory.rb
+++ b/lib/active_record/events/method_factory.rb
@@ -51,7 +51,7 @@ module ActiveRecord
           if persisted?
             touch(naming.field)
           else
-            send("#{naming.field}=", Time.zone.now)
+            self[naming.field] = current_time_from_proper_timezone
           end
         end
       end

--- a/lib/active_record/events/method_factory.rb
+++ b/lib/active_record/events/method_factory.rb
@@ -48,7 +48,11 @@ module ActiveRecord
 
       def define_action_method(module_, naming)
         module_.send(:define_method, naming.action) do
-          touch(naming.field)
+          if persisted?
+            touch(naming.field)
+          else
+            send("#{naming.field}=", Time.zone.now)
+          end
         end
       end
 

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -32,6 +32,14 @@ RSpec.describe ActiveRecord::Events do
     expect(task.completed_at).to eq(Time.current)
   end
 
+  it 'On non-persisted object, it updates the timestamp' do
+    task = build(:task, completed_at: 3.days.ago)
+
+    task.complete!
+
+    expect(task.completed_at).to eq(Time.current)
+  end
+
   it 'records multiple timestamps at once' do
     Task.complete_all
 

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -32,12 +32,14 @@ RSpec.describe ActiveRecord::Events do
     expect(task.completed_at).to eq(Time.current)
   end
 
-  it 'On non-persisted object, it updates the timestamp' do
-    task = build(:task, completed_at: 3.days.ago)
+  context 'with a non-persisted object' do
+    it 'updates the timestamp' do
+      task = build(:task, completed_at: 3.days.ago)
 
-    task.complete!
+      task.complete!
 
-    expect(task.completed_at).to eq(Time.current)
+      expect(task.completed_at).to eq(Time.current)
+    end
   end
 
   it 'records multiple timestamps at once' do


### PR DESCRIPTION
This adds a check for if the timestamp field is persisted, which avoids seeing the exception:

> Cannot touch on a new or destroyed record object. Consider using persisted?, new_record?, or destroyed? before touching.

# Deeper Description

I used this gem within a form object:

```ruby
class User::SignUp < ActiveType::Record[User]
  validates :accepted_terms_of_use, acceptance: true

  has_event :accepted_terms_of_use, skip_scopes: true, field_name: :accepted_terms_of_use_at
  has_event :allowed_follow_up_messages, skip_scopes: true, field_name: :allowed_follow_up_messages_at

end
```

When the form submitted with the param `{accepted_terms_of_use: '1'}`, it would touch the field `accepted_terms_of_use` which caused the exception to be thrown.

I'm not precious about this PR if you're not fussed about this, but it was kind of a quirky one to see :)