### PR TITLE
Support time comparisons

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,6 +4,7 @@ AllCops:
   Exclude:
     - vendor/**/*
     - spec/dummy/db/schema.rb
+    - tmp/**/*
 
 Style/Documentation:
   Enabled: false

--- a/README.md
+++ b/README.md
@@ -119,6 +119,28 @@ has_event :complete, field_name: :completion_time
 
 Note that the `field_name` option takes precedence over the `field_type` option.
 
+### Comparison strategy
+
+By default the field's presence will dictate the behavior. However in some cases you may want to check against the current time.
+
+You can do this with the `strategy` option, which can be either `presence` or `time_comparison`:
+
+```ruby
+has_event :complete, strategy: :time_comparison
+```
+
+**Example:**
+
+```ruby
+task.completed_at = 1.hour.ago
+task.completed? # => true
+Task.completed  # => [...]
+
+task.completed_at = 1.hour.from_now
+task.completed? # => false
+Task.completed  # => []
+```
+
 ### Specifying an object
 
 There are events which do not relate to a model itself but to one of its attributes – take the `User` model with the `email_confirmed_at` field as an example.

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Note that the `field_name` option takes precedence over the `field_type` option.
 
 ### Comparison strategy
 
-By default the field's presence will dictate the behavior. However in some cases you may want to check against the current time.
+By default the timestamp's presence will dictate the behavior. However in some cases you may want to check against the current time.
 
 You can do this with the `strategy` option, which can be either `presence` or `time_comparison`:
 
@@ -134,11 +134,9 @@ has_event :complete, strategy: :time_comparison
 ```ruby
 task.completed_at = 1.hour.ago
 task.completed? # => true
-Task.completed  # => [...]
 
 task.completed_at = 1.hour.from_now
 task.completed? # => false
-Task.completed  # => []
 ```
 
 ### Specifying an object

--- a/lib/active_record/events/method_factory.rb
+++ b/lib/active_record/events/method_factory.rb
@@ -90,11 +90,12 @@ module ActiveRecord
 
       def define_inverse_scope_method(module_, naming, strategy)
         module_.send(:define_method, naming.inverse_scope) do
+          arel_field = arel_table[naming.field]
+
           if strategy == :time_comparison
-            where(arel_table[naming.field].eq(nil)
-              .or(arel_table[naming.field].gt(Time.current)))
+            where(arel_field.eq(nil).or(arel_field.gt(Time.current)))
           else
-            where(arel_table[naming.field].eq(nil))
+            where(arel_field.eq(nil))
           end
         end
       end

--- a/lib/generators/active_record/event/event_generator.rb
+++ b/lib/generators/active_record/event/event_generator.rb
@@ -40,8 +40,9 @@ module ActiveRecord
 
         macro_options = options.slice(*MACRO_OPTIONS)
         macro = ActiveRecord::Events::Macro.new(event_name, macro_options)
+        pattern = /^\s*class\s.+\n/
 
-        inject_into_file model_file_path, "\s\s#{macro}\n", after: /^\s*class\s.+\n/
+        inject_into_file model_file_path, "\s\s#{macro}\n", after: pattern
       end
 
       private

--- a/lib/generators/active_record/event/event_generator.rb
+++ b/lib/generators/active_record/event/event_generator.rb
@@ -6,7 +6,7 @@ require 'active_record/events/macro'
 module ActiveRecord
   module Generators
     class EventGenerator < Rails::Generators::Base
-      MACRO_OPTIONS = %w[object field_type skip_scopes].freeze
+      MACRO_OPTIONS = %w[object field_type skip_scopes strategy].freeze
 
       argument :model_name, type: :string
       argument :event_name, type: :string
@@ -17,6 +17,8 @@ module ActiveRecord
         desc: 'The field type (datetime or date)'
       class_option :object, type: :string,
         desc: 'The name of the object'
+      class_option :strategy, type: :string,
+        desc: 'Define comparison strategy, presence or time_comparison'
 
       source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/active_record/event/event_generator.rb
+++ b/lib/generators/active_record/event/event_generator.rb
@@ -18,7 +18,7 @@ module ActiveRecord
       class_option :object, type: :string,
         desc: 'The name of the object'
       class_option :strategy, type: :string,
-        desc: 'Define comparison strategy, presence or time_comparison'
+        desc: 'The comparison strategy (presence or time_comparison)'
 
       source_root File.expand_path('templates', __dir__)
 

--- a/lib/generators/active_record/event/event_generator.rb
+++ b/lib/generators/active_record/event/event_generator.rb
@@ -41,7 +41,7 @@ module ActiveRecord
         macro_options = options.slice(*MACRO_OPTIONS)
         macro = ActiveRecord::Events::Macro.new(event_name, macro_options)
 
-        inject_into_file model_file_path, "\s\s#{macro}\n", after: /class.+\n/
+        inject_into_file model_file_path, "\s\s#{macro}\n", after: /^\s*class\s.+\n/
       end
 
       private

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ActiveRecord::Events do
     expect(task.reload).to be_completed
   end
 
-  context 'when strategy is time_comparison' do
+  context 'when the strategy is time comparison' do
     it 'defines a predicate method comparing against current time' do
       task.update_columns(expired_at: 1.hour.from_now)
       expect(task.expired?).to eq(false)

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -71,4 +71,50 @@ RSpec.describe ActiveRecord::Events do
 
     expect(task.reload).to be_completed
   end
+
+  context 'when strategy is time_comparison' do
+    it 'defines a predicate method comparing against current time' do
+      task.update_columns(expired_at: 1.hour.from_now)
+      expect(task.expired?).to eq(false)
+
+      task.update_columns(expired_at: 1.hour.ago)
+      expect(task.expired?).to eq(true)
+
+      task.update_columns(expired_at: nil)
+      expect(task.expired?).to eq(false)
+    end
+
+    it 'defines an inverse predicate method comparing against current time' do
+      task.update_columns(expired_at: 1.hour.from_now)
+      expect(task.not_expired?).to eq(true)
+
+      task.update_columns(expired_at: 1.hour.ago)
+      expect(task.not_expired?).to eq(false)
+
+      task.update_columns(expired_at: nil)
+      expect(task.not_expired?).to eq(true)
+    end
+
+    it 'defines a scope comparing against current time' do
+      task.update_columns(expired_at: 1.hour.from_now)
+      expect(Task.expired).not_to include(task)
+
+      task.update_columns(expired_at: 1.hour.ago)
+      expect(Task.expired).to include(task)
+
+      task.update_columns(expired_at: nil)
+      expect(Task.expired).not_to include(task)
+    end
+
+    it 'defines an inverse scope comparing against current time' do
+      task.update_columns(expired_at: 1.hour.from_now)
+      expect(Task.not_expired).to include(task)
+
+      task.update_columns(expired_at: 1.hour.ago)
+      expect(Task.not_expired).not_to include(task)
+
+      task.update_columns(expired_at: nil)
+      expect(Task.not_expired).to include(task)
+    end
+  end
 end

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -72,7 +72,7 @@ RSpec.describe ActiveRecord::Events do
     expect(task.reload).to be_completed
   end
 
-  context 'when the strategy is time comparison' do
+  describe 'time comparison strategy' do
     it 'defines a predicate method comparing against current time' do
       task.update_columns(expired_at: 1.hour.from_now)
       expect(task.expired?).to eq(false)

--- a/spec/dummy/app/models/task.rb
+++ b/spec/dummy/app/models/task.rb
@@ -1,6 +1,6 @@
 class Task < ActiveRecord::Base
   has_event :complete
-  has_events :archive, skip_scopes: true
+  has_event :archive, skip_scopes: true
   has_events :expire, strategy: :time_comparison
 
   def complete!

--- a/spec/dummy/app/models/task.rb
+++ b/spec/dummy/app/models/task.rb
@@ -1,6 +1,7 @@
 class Task < ActiveRecord::Base
   has_event :complete
   has_events :archive, skip_scopes: true
+  has_events :expire, strategy: :time_comparison
 
   def complete!
     super

--- a/spec/dummy/db/migrate/20150813132804_create_tasks.rb
+++ b/spec/dummy/db/migrate/20150813132804_create_tasks.rb
@@ -2,6 +2,7 @@ class CreateTasks < ACTIVE_RECORD_MIGRATION_CLASS
   def change
     create_table :tasks do |t|
       t.datetime :completed_at
+      t.datetime :expired_at
 
       t.timestamps null: false
     end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2015_08_13_132804) do
+ActiveRecord::Schema.define(version: 2015_08_13_132804) do
   create_table "tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "expired_at"

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,10 +10,10 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2015_08_13_132804) do
-
+ActiveRecord::Schema[7.0].define(version: 2015_08_13_132804) do
   create_table "tasks", force: :cascade do |t|
     t.datetime "completed_at"
+    t.datetime "expired_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
   end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2015_08_13_132804) do
+
   create_table "tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "expired_at"

--- a/spec/generators/active_record/event/event_generator_spec.rb
+++ b/spec/generators/active_record/event/event_generator_spec.rb
@@ -2,7 +2,13 @@ require 'spec_helper'
 require 'generators/active_record/event/event_generator'
 
 RSpec.describe ActiveRecord::Generators::EventGenerator, type: :generator do
-  arguments %w[task complete --field-type=date --skip-scopes --strategy=time_comparison]
+  arguments %w[
+    task complete
+    --field-type=date
+    --skip-scopes
+    --strategy=time_comparison
+  ]
+
   destination File.expand_path('../../../../tmp', __dir__)
 
   before { prepare_destination }

--- a/spec/generators/active_record/event/event_generator_spec.rb
+++ b/spec/generators/active_record/event/event_generator_spec.rb
@@ -2,7 +2,7 @@ require 'spec_helper'
 require 'generators/active_record/event/event_generator'
 
 RSpec.describe ActiveRecord::Generators::EventGenerator, type: :generator do
-  arguments %w[task complete --field-type=date --skip-scopes]
+  arguments %w[task complete --field-type=date --skip-scopes --strategy=time_comparison]
   destination File.expand_path('../../../../tmp', __dir__)
 
   before { prepare_destination }
@@ -30,7 +30,7 @@ RSpec.describe ActiveRecord::Generators::EventGenerator, type: :generator do
 
       assert_file 'app/models/task.rb', <<-RUBY.strip_heredoc
         class Task < ActiveRecord::Base
-          has_event :complete, field_type: :date, skip_scopes: true
+          has_event :complete, field_type: :date, skip_scopes: true, strategy: :time_comparison
         end
       RUBY
     end


### PR DESCRIPTION
Really enjoy this gem DRYing up codebases! I've also found myself needing to support the following on occasion:

### Example (Before)

```rb
class Invitation < ActiveRecord::Base
  scope :expired, -> { where.not(expired_at: nil).where(expired_at: ...Time.zone.now) }
  
  def expired?
    expired_at && expired_at <= Time.zone.now
  end
end

Invitate.create!(expired_at: 3.days.from_now)
```

This PR proposes a `strategy` option which allows an additional check against current time.

### Example (Proposal)

```rb
class Invitation < ActiveRecord::Base
  has_event :expire, strategy: :time_comparison
end

invitation = Invitate.create!(expired_at: 3.days.from_now)
invitation.expired? # => false

travel_to(4.days.from_now) do
  invitation.expired? # => true
end
```

Thoughts on adding this use case? Thanks!