### PR TITLE
Fix time_comparison for dates

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,7 @@ end
 - [Oskar Janusz](https://github.com/oskaror)
 - [Mike Rogers](https://github.com/MikeRogers0)
 - [Spencer Rogers](https://github.com/serogers)
+- [Benno Bielmeier](https://github.com/bbenno)
 
 ## See also
 

--- a/lib/active_record/events/method_factory.rb
+++ b/lib/active_record/events/method_factory.rb
@@ -39,7 +39,7 @@ module ActiveRecord
       def define_predicate_method(module_, naming, strategy)
         module_.send(:define_method, naming.predicate) do
           if strategy == :time_comparison
-            self[naming.field].present? && self[naming.field].past?
+            self[naming.field].present? && !self[naming.field].future?
           else
             self[naming.field].present?
           end

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -118,17 +118,17 @@ RSpec.describe ActiveRecord::Events do
     end
 
     describe 'for date fields' do
-      it 'consider today\'s event over' do
+      it "considers today's event over" do
         task.update_columns(notified_on: Date.today)
         expect(task.notified?).to eq(true)
       end
 
-      it 'consider tomorrow\'s event pending' do
+      it "considers tomorrow's event pending" do
         task.update_columns(notified_on: Date.tomorrow)
         expect(task.notified?).to eq(false)
       end
 
-      it 'consider yesterday\'s event over' do
+      it "considers yesterday's event over" do
         task.update_columns(notified_on: Date.yesterday)
         expect(task.notified?).to eq(true)
       end

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -116,5 +116,22 @@ RSpec.describe ActiveRecord::Events do
       task.update_columns(expired_at: nil)
       expect(Task.not_expired).to include(task)
     end
+
+    describe 'for date fields' do
+      it 'consider today\'s event over' do
+        task.update_columns(notified_on: Date.today)
+        expect(task.notified?).to eq(true)
+      end
+
+      it 'consider tomorrow\'s event pending' do
+        task.update_columns(notified_on: Date.tomorrow)
+        expect(task.notified?).to eq(false)
+      end
+
+      it 'consider yesterday\'s event over' do
+        task.update_columns(notified_on: Date.yesterday)
+        expect(task.notified?).to eq(true)
+      end
+    end
   end
 end

--- a/spec/active_record/events_spec.rb
+++ b/spec/active_record/events_spec.rb
@@ -132,6 +132,16 @@ RSpec.describe ActiveRecord::Events do
         task.update_columns(notified_on: Date.yesterday)
         expect(task.notified?).to eq(true)
       end
+
+      it 'includes current date in scope' do
+        task.update_columns(notified_on: Date.current)
+        expect(Task.notified).to include(task)
+      end
+
+      it 'excludes current date in inverse scope' do
+        task.update_columns(notified_on: Date.current)
+        expect(Task.not_notified).not_to include(task)
+      end
     end
   end
 end

--- a/spec/dummy/app/models/task.rb
+++ b/spec/dummy/app/models/task.rb
@@ -2,6 +2,7 @@ class Task < ActiveRecord::Base
   has_event :complete
   has_event :archive, skip_scopes: true
   has_events :expire, strategy: :time_comparison
+  has_event :notify, field_type: :date, strategy: :time_comparison
 
   def complete!
     super

--- a/spec/dummy/db/migrate/20230308160359_add_notified_on_to_tasks.rb
+++ b/spec/dummy/db/migrate/20230308160359_add_notified_on_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddNotifiedOnToTasks < ACTIVE_RECORD_MIGRATION_CLASS
+  def change
+    add_column :tasks, :notified_on, :date
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_06_09_015338) do
+ActiveRecord::Schema.define(version: 2023_03_08_160359) do
 
   create_table "tasks", force: :cascade do |t|
     t.datetime "completed_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "expired_at"
+    t.date "notified_on"
   end
 
 end


### PR DESCRIPTION
Assume an ActiveRecord with a release date

```
has_event :release, field_type: :date, strategy: :time_comparison
```

and let's further that the release date is `Date.today`.
Previously calling `#released?` will return `false` due to [checking with `#past?`][1]. Although, `true` might have been expected in this situation due to considering the release date as "the first date being released".
The new behavior returns `true` for exactly this edge case of date-events with time_comparison strategy by using `! #future?` instead of `#past?`.

[1]: https://github.com/pienkowb/active_record-events/blob/2814f2d3828ab69b4cb22890a50d0a77b21ff7cd/lib/active_record/events/method_factory.rb#L42

EDIT: an alternative approach (in case the previous behavior is intended) I favor a new strategy with the described behavior. 